### PR TITLE
Renamed wrong package

### DIFF
--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/AbstractTest.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/AbstractTest.java
@@ -26,7 +26,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import it.cnr.iasi.leks.debspread.tests.util.PropertyUtilNoSingleton;
+import it.cnr.iasi.leks.bedspread.tests.util.PropertyUtilNoSingleton;
 
 /*
  * @author gulyx

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/BasicSemanticSpreadOnDBpediaTest.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/BasicSemanticSpreadOnDBpediaTest.java
@@ -35,7 +35,7 @@ import it.cnr.iasi.leks.bedspread.rdf.KnowledgeBase;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFFactory;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFGraph;
 import it.cnr.iasi.leks.bedspread.rdf.sparqlImpl.DBpediaKB;
-import it.cnr.iasi.leks.debspread.tests.util.PropertyUtilNoSingleton;
+import it.cnr.iasi.leks.bedspread.tests.util.PropertyUtilNoSingleton;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/EdgeWeighting_ICTest.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/EdgeWeighting_ICTest.java
@@ -30,10 +30,10 @@ import it.cnr.iasi.leks.bedspread.impl.weights.ic.EdgeWeighting_JointIC;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFFactory;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFTriple;
 import it.cnr.iasi.leks.bedspread.rdf.sparqlImpl.DBpediaKB;
-import it.cnr.iasi.leks.debspread.tests.util.weightsIC.EdgeWeighting_CombIC_Test;
-import it.cnr.iasi.leks.debspread.tests.util.weightsIC.EdgeWeighting_IC_PMI_Test;
-import it.cnr.iasi.leks.debspread.tests.util.weightsIC.EdgeWeighting_IC_Test;
-import it.cnr.iasi.leks.debspread.tests.util.weightsIC.EdgeWeighting_JointIC_Test;
+import it.cnr.iasi.leks.bedspread.tests.util.weightsIC.EdgeWeighting_CombIC_Test;
+import it.cnr.iasi.leks.bedspread.tests.util.weightsIC.EdgeWeighting_IC_PMI_Test;
+import it.cnr.iasi.leks.bedspread.tests.util.weightsIC.EdgeWeighting_IC_Test;
+import it.cnr.iasi.leks.bedspread.tests.util.weightsIC.EdgeWeighting_JointIC_Test;
 
 public class EdgeWeighting_ICTest {
 

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/PolicentricSemanticSpreadTest.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/PolicentricSemanticSpreadTest.java
@@ -39,8 +39,8 @@ import it.cnr.iasi.leks.bedspread.rdf.AnyResource;
 import it.cnr.iasi.leks.bedspread.rdf.KnowledgeBase;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFFactory;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFGraph;
+import it.cnr.iasi.leks.bedspread.tests.util.PropertyUtilNoSingleton;
 import it.cnr.iasi.leks.bedspread.util.SetOfNodesFactory;
-import it.cnr.iasi.leks.debspread.tests.util.PropertyUtilNoSingleton;
 
 public class PolicentricSemanticSpreadTest extends AbstractTest{
 	

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/PropertyUtilTest.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/PropertyUtilTest.java
@@ -22,7 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import it.cnr.iasi.leks.bedspread.config.PropertyUtil;
-import it.cnr.iasi.leks.debspread.tests.util.PropertyUtilNoSingleton;
+import it.cnr.iasi.leks.bedspread.tests.util.PropertyUtilNoSingleton;
 
 /**
  * 

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/SemanticSpreadOnDBpediaTest.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/SemanticSpreadOnDBpediaTest.java
@@ -34,7 +34,7 @@ import it.cnr.iasi.leks.bedspread.rdf.AnyResource;
 import it.cnr.iasi.leks.bedspread.rdf.KnowledgeBase;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFFactory;
 import it.cnr.iasi.leks.bedspread.rdf.sparqlImpl.DBpediaKB;
-import it.cnr.iasi.leks.debspread.tests.util.PropertyUtilNoSingleton;
+import it.cnr.iasi.leks.bedspread.tests.util.PropertyUtilNoSingleton;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/SemanticSpreadOnWhiteboardRDFGraph_modifiedTest.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/SemanticSpreadOnWhiteboardRDFGraph_modifiedTest.java
@@ -35,7 +35,7 @@ import it.cnr.iasi.leks.bedspread.rdf.AnyResource;
 import it.cnr.iasi.leks.bedspread.rdf.KnowledgeBase;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFFactory;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFGraph;
-import it.cnr.iasi.leks.debspread.tests.util.PropertyUtilNoSingleton;
+import it.cnr.iasi.leks.bedspread.tests.util.PropertyUtilNoSingleton;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/SemanticSpreadTest.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/SemanticSpreadTest.java
@@ -37,7 +37,7 @@ import it.cnr.iasi.leks.bedspread.rdf.AnyResource;
 import it.cnr.iasi.leks.bedspread.rdf.KnowledgeBase;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFFactory;
 import it.cnr.iasi.leks.bedspread.rdf.impl.RDFGraph;
-import it.cnr.iasi.leks.debspread.tests.util.PropertyUtilNoSingleton;
+import it.cnr.iasi.leks.bedspread.tests.util.PropertyUtilNoSingleton;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/WeightingFunctionTest.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/WeightingFunctionTest.java
@@ -28,7 +28,7 @@ import it.cnr.iasi.leks.bedspread.config.PropertyUtil;
 import it.cnr.iasi.leks.bedspread.impl.weights.DefaultWeightingFunction;
 import it.cnr.iasi.leks.bedspread.impl.weights.SemanticWeightingFunction;
 import it.cnr.iasi.leks.bedspread.impl.weights.WeightingFunctionFactory;
-import it.cnr.iasi.leks.debspread.tests.util.PropertyUtilNoSingleton;
+import it.cnr.iasi.leks.bedspread.tests.util.PropertyUtilNoSingleton;
 import junit.framework.Assert;
 
 /**

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/PropertyUtilNoSingleton.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/PropertyUtilNoSingleton.java
@@ -16,7 +16,7 @@
  *	 You should have received a copy of the GNU General Public License
  *	 along with this source.  If not, see <http://www.gnu.org/licenses/>.
  */
-package it.cnr.iasi.leks.debspread.tests.util;
+package it.cnr.iasi.leks.bedspread.tests.util;
 
 import it.cnr.iasi.leks.bedspread.config.PropertyUtil;
 

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/SPARQLEndpointConnectorTest.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/SPARQLEndpointConnectorTest.java
@@ -16,7 +16,7 @@
  *	 You should have received a copy of the GNU General Public License
  *	 along with this source.  If not, see <http://www.gnu.org/licenses/>.
  */
-package it.cnr.iasi.leks.debspread.tests.util;
+package it.cnr.iasi.leks.bedspread.tests.util;
 
 import java.util.Vector;
 

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/weightsIC/EdgeWeighting_CombIC_Test.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/weightsIC/EdgeWeighting_CombIC_Test.java
@@ -29,6 +29,7 @@ import it.cnr.iasi.leks.bedspread.rdf.KnowledgeBase;
  * @author gulyx
  *
  */
+
 public class EdgeWeighting_CombIC_Test extends EdgeWeighting_CombIC{
 
 	public EdgeWeighting_CombIC_Test(KnowledgeBase kb) {

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/weightsIC/EdgeWeighting_CombIC_Test.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/weightsIC/EdgeWeighting_CombIC_Test.java
@@ -16,7 +16,7 @@
  *	 You should have received a copy of the GNU General Public License
  *	 along with this source.  If not, see <http://www.gnu.org/licenses/>.
  */
-package it.cnr.iasi.leks.debspread.tests.util.weightsIC;
+package it.cnr.iasi.leks.bedspread.tests.util.weightsIC;
 
 import it.cnr.iasi.leks.bedspread.impl.weights.ic.EdgeWeighting_CombIC;
 import it.cnr.iasi.leks.bedspread.rdf.AnyResource;

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/weightsIC/EdgeWeighting_IC_PMI_Test.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/weightsIC/EdgeWeighting_IC_PMI_Test.java
@@ -16,7 +16,7 @@
  *	 You should have received a copy of the GNU General Public License
  *	 along with this source.  If not, see <http://www.gnu.org/licenses/>.
  */
-package it.cnr.iasi.leks.debspread.tests.util.weightsIC;
+package it.cnr.iasi.leks.bedspread.tests.util.weightsIC;
 
 import it.cnr.iasi.leks.bedspread.impl.weights.ic.EdgeWeighting_IC_PMI;
 import it.cnr.iasi.leks.bedspread.rdf.AnyResource;

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/weightsIC/EdgeWeighting_IC_Test.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/weightsIC/EdgeWeighting_IC_Test.java
@@ -16,9 +16,9 @@
  *	 You should have received a copy of the GNU General Public License
  *	 along with this source.  If not, see <http://www.gnu.org/licenses/>.
  */
-package it.cnr.iasi.leks.debspread.tests.util.weightsIC;
+package it.cnr.iasi.leks.bedspread.tests.util.weightsIC;
 
-import it.cnr.iasi.leks.bedspread.impl.weights.ic.EdgeWeighting_JointIC;
+import it.cnr.iasi.leks.bedspread.impl.weights.ic.EdgeWeighting_IC;
 import it.cnr.iasi.leks.bedspread.rdf.AnyResource;
 import it.cnr.iasi.leks.bedspread.rdf.KnowledgeBase;
 
@@ -29,18 +29,18 @@ import it.cnr.iasi.leks.bedspread.rdf.KnowledgeBase;
  * @author gulyx
  *
  */
-public class EdgeWeighting_JointIC_Test extends EdgeWeighting_JointIC {
+public class EdgeWeighting_IC_Test extends EdgeWeighting_IC{
 
-	public EdgeWeighting_JointIC_Test(KnowledgeBase kb) {
+	public EdgeWeighting_IC_Test(KnowledgeBase kb) {
 		super(kb);
 	}
-	
-	public double nodeProbabilityConditionalToPredicate(AnyResource pred, AnyResource node) {
-		return super.nodeProbabilityConditionalToPredicate(pred, node);
+
+	public double predicateProbability(AnyResource resource) {
+		return super.predicateProbability(resource);
+	}  
+		
+	public double predicate_IC(AnyResource resource) {
+		return super.predicate_IC(resource);
 	}
 
-	public double nodeConditionalToPredicate_IC(AnyResource pred, AnyResource node) {
-		return super.nodeConditionalToPredicate_IC(pred, node);
-	}
-	
 }

--- a/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/weightsIC/EdgeWeighting_JointIC_Test.java
+++ b/bedspread-core/src/test/java/it/cnr/iasi/leks/bedspread/tests/util/weightsIC/EdgeWeighting_JointIC_Test.java
@@ -16,9 +16,9 @@
  *	 You should have received a copy of the GNU General Public License
  *	 along with this source.  If not, see <http://www.gnu.org/licenses/>.
  */
-package it.cnr.iasi.leks.debspread.tests.util.weightsIC;
+package it.cnr.iasi.leks.bedspread.tests.util.weightsIC;
 
-import it.cnr.iasi.leks.bedspread.impl.weights.ic.EdgeWeighting_IC;
+import it.cnr.iasi.leks.bedspread.impl.weights.ic.EdgeWeighting_JointIC;
 import it.cnr.iasi.leks.bedspread.rdf.AnyResource;
 import it.cnr.iasi.leks.bedspread.rdf.KnowledgeBase;
 
@@ -29,18 +29,18 @@ import it.cnr.iasi.leks.bedspread.rdf.KnowledgeBase;
  * @author gulyx
  *
  */
-public class EdgeWeighting_IC_Test extends EdgeWeighting_IC{
+public class EdgeWeighting_JointIC_Test extends EdgeWeighting_JointIC {
 
-	public EdgeWeighting_IC_Test(KnowledgeBase kb) {
+	public EdgeWeighting_JointIC_Test(KnowledgeBase kb) {
 		super(kb);
 	}
-
-	public double predicateProbability(AnyResource resource) {
-		return super.predicateProbability(resource);
-	}  
-		
-	public double predicate_IC(AnyResource resource) {
-		return super.predicate_IC(resource);
+	
+	public double nodeProbabilityConditionalToPredicate(AnyResource pred, AnyResource node) {
+		return super.nodeProbabilityConditionalToPredicate(pred, node);
 	}
 
+	public double nodeConditionalToPredicate_IC(AnyResource pred, AnyResource node) {
+		return super.nodeConditionalToPredicate_IC(pred, node);
+	}
+	
 }


### PR DESCRIPTION
Renamed wrong package "it.cnr.iasi.leks.debspread.tests.util" into the correct "it.cnr.iasi.leks.bedspread.tests.util"

Updated Related references.

@ftaglino 