### PR TITLE
computeMaxWeight method has been fixed.

### DIFF
--- a/bedspread-core/src/main/java/it/cnr/iasi/leks/bedspread/impl/weights/ic/EdgeWeighting_IC.java
+++ b/bedspread-core/src/main/java/it/cnr/iasi/leks/bedspread/impl/weights/ic/EdgeWeighting_IC.java
@@ -69,8 +69,9 @@ public class EdgeWeighting_IC extends Abstract_EdgeWeighting_IC{
 			this.reportSomeInfoOnTheLog(size);
 			size --;
 			double w = this.predicate_IC(p);
-			if(w>result)
-				result = w;
+			if(w != Double.POSITIVE_INFINITY)
+				if(w>result)
+					result = w;
 		}
 		return result;			
 	}


### PR DESCRIPTION
The method computeMaxWeight 
- firstly, finds all the predicates defined in the dbo namespace
- secondly, for each of the predicates defined in the dbo namespace, it computes the Information Content.

The reason of the problem was that there are some predicates defined in the dbo namespace that are not currently used for linking resources in the dbr namespace. Consequently, in the computation of the max weight we need to skip such predicates, otherwise the max weight is equal to POSITIVE INFINITE, and the weight associated to any edge is equal to 0. 
